### PR TITLE
Update gcc version

### DIFF
--- a/docs/nativecomp.md
+++ b/docs/nativecomp.md
@@ -14,7 +14,7 @@ HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc --build-from-source --force
 ```
 ./deps.sh
 
-LDFLAGS="-L/usr/local/Cellar/gcc/10.1.0/lib/gcc/10/" \
+LDFLAGS="-L/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/" \
 FEATURES="--with-nativecomp" \
 NATIVE_FAST_BOOT=1 BYTE_COMPILE_EXTRA_FLAGS='--eval "(setq comp-speed 3)"' \
   ./build.sh -B feature/native-comp -c -b -i


### PR DESCRIPTION
LDFLAGS now points to gcc 10.2.0 instead of 10.1.0 to reflect the current version of gcc